### PR TITLE
Optimizing responsiveness

### DIFF
--- a/app/members/[slug]/page.tsx
+++ b/app/members/[slug]/page.tsx
@@ -21,18 +21,19 @@ export default async function Member({ params }: Props) {
   return (
     <div className="w-full pt-20">
       <div className={styles.topBar} />
-      <article className="max-w-screen-lg relative mx-auto py-16">
-        <div className="inline-block text-center">
+      <article className="relative py-16 lg:max-w-screen-lg lg:mx-auto">
+        <div className="text-center lg:inline-block">
           <Image
             src={`/img/members/${params.slug}.jpg`}
             alt={name}
             width="250"
             height="250"
-            className="rounded-xl y-8"
+            className="rounded-xl y-8 "
           />
           <SocialLinks member={member} />
         </div>
-        <h2 className="mt-3">{name}</h2>
+        <div className="text-center lg:text-left">
+        <h2 className="mt-3 text-3xl lg:text-4xl">{name}</h2>
         <h3>{affiliation}</h3>
         <h3 className={styles.affiliation}>{level}</h3>
         {countries && <CountryFlags countries={countries} />}
@@ -42,6 +43,7 @@ export default async function Member({ params }: Props) {
             dangerouslySetInnerHTML={{ __html: bio }}
           />
         )}
+        </div>
       </article>
     </div>
   );

--- a/app/members/[slug]/page.tsx
+++ b/app/members/[slug]/page.tsx
@@ -32,7 +32,7 @@ export default async function Member({ params }: Props) {
           />
           <SocialLinks member={member} />
         </div>
-        <div className="text-center lg:text-left">
+        <div className="text-center p-10 lg:p-0 lg:text-left">
         <h2 className="mt-3 text-3xl lg:text-4xl">{name}</h2>
         <h3>{affiliation}</h3>
         <h3 className={styles.affiliation}>{level}</h3>

--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -7,7 +7,7 @@ export default async function MembersPage() {
   const members: MemberInterface[] = await getMembers();
   return (
     <div className={styles.center}>
-      <h1 className="mt-20 text-5xl sm:text-6xl">All Members</h1>
+      <h1 className="mt-20 text-5xl sm:text-6xl">Members</h1>
       <div className="mt-20 grid grid-cols-1 gap-y-12 md:grid md:grid-cols-2 md-grid-rows md:gap-x-12 lg:grid lg:grid-cols-3 lg:grid-rows lg:gap-x-10">
         {members.map((member) => (
           <MemberCard key={member.slug} member={member} />

--- a/components/Homepage/MemberPreview/MemberPreview.tsx
+++ b/components/Homepage/MemberPreview/MemberPreview.tsx
@@ -24,7 +24,7 @@ const MemberPreview = (props: Props) => {
 
   return (
     <section className={styles.avatars}>
-      <h2>Some of our members</h2>
+      <h2>Member Preview</h2>
       <div className="mt-10 mb-20 grid grid-cols-1 gap-y-10 md:grid md:grid-cols-2 md:grid-rows-3 md:gap-x-10 lg:grid lg:grid-cols-3 lg:grid-rows-2 lg:gap-x-10">
         {membersRandom.slice(0, 6).map((member) => (
           <MemberCard key={member.slug} member={member} />
@@ -32,7 +32,7 @@ const MemberPreview = (props: Props) => {
       </div>
       <div>
         <ButtonLink
-          text="View all members"
+          text="View all our Members "
           url="/members"
           icon={faMagnifyingGlass}
         />

--- a/components/Homepage/MemberPreview/MemberPreview.tsx
+++ b/components/Homepage/MemberPreview/MemberPreview.tsx
@@ -1,7 +1,7 @@
 import ButtonLink from "@/components/ButtonLink/ButtonLink";
 import MemberCard from "@/components/MemberCard/MemberCard";
 import { MemberInterface } from "@/types/members";
-import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import { faPeopleGroup } from "@fortawesome/free-solid-svg-icons";
 import styles from "./MembersSnippet.module.css";
 
 interface Props {
@@ -34,7 +34,7 @@ const MemberPreview = (props: Props) => {
         <ButtonLink
           text="View all our Members "
           url="/members"
-          icon={faMagnifyingGlass}
+          icon={faPeopleGroup}
         />
       </div>
     </section>

--- a/components/Navbar/Navbar.module.css
+++ b/components/Navbar/Navbar.module.css
@@ -2,7 +2,9 @@
   justify-content: space-between;
   font-weight: bold;
   text-align: center;
+  margin: 10px;
   margin-top: 25px;
+  
 }
 
 .navbar ul {
@@ -13,6 +15,11 @@
 .navbar li {
   list-style: none;
   display: inline;
+}
+
+.navbar a {
+  margin-bottom: 15px;
+  text-decoration: underline;
 }
 
 .navbar li:hover {

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -6,20 +6,20 @@ export default function Navbar() {
     <nav className={styles.navbar}>
       <ul>
         <li>
-          <Link href="/" className="underline">
+          <Link href="/">
             Home
           </Link>
         </li>
         <li>
-          <Link href="/members/" className="pl-4 sm:pl-10 underline">
-            All Members
+          <Link href="/members/" className="pl-4 sm:pl-10">
+            Members
           </Link>
         </li>
         <li>
           <Link
             href="https://forms.fillout.com/t/xARDm8SG6mus"
             target={"_blank"}
-            className="pl-4 sm:pl-10 underline"
+            className="pl-4 sm:pl-10 inline-block"
           >
             Add your profile
           </Link>
@@ -28,7 +28,7 @@ export default function Navbar() {
           <Link
             href="https://github.com/FrancesCoronel/latina-dev"
             target={"_blank"}
-            className="pl-4 sm:pl-10 underline"
+            className="pl-4 sm:pl-10"
           >
             Contribute
           </Link>


### PR DESCRIPTION
## Overview

Optimized responsiveness of single profile layout and navbar. (The single profile page now centers and name font size now adjusts when viewed on mobile devices). 

I also changed language on homepage from "Some of our members" to "Member Preview" and renamed "Members" page now that's its clearer.

## Relevant Issue

Single Profile Layout

---

<!-- Thank you for contributing to Latina Dev, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

> ✅️ By submitting this PR, I have verified the following

- [x] Reviewed the [contributing guidelines](https://github.com/Latina-Dev/latina-dev/blob/master/.github/CONTRIBUTING.md) 🔍️
- [x] Added my name to the bottom of the list under the **Contributors** section in the [README.md](https://github.com/Latina-Dev/latina-dev/blob/master/README.md) with a link to my personal website or GitHub profile 👥️
