### PR TITLE
fix: improve mobile layout for cards, buttons, spacing, and typography

### DIFF
--- a/app/members/[slug]/page.tsx
+++ b/app/members/[slug]/page.tsx
@@ -67,11 +67,11 @@ export default async function Member({ params }: Props) {
             alt={name}
             width="250"
             height="250"
-            className="rounded-xl my-8"
+            className="rounded-xl my-8 w-40 h-40 sm:w-52 sm:h-52 md:w-[250px] md:h-[250px]"
           />
           <SocialLinks member={member} />
         </div>
-        <div className="text-center p-10 lg:p-0 lg:pt-8 lg:text-left">
+        <div className="text-center px-4 py-6 sm:px-8 sm:py-8 lg:p-0 lg:pt-8 lg:text-left">
           <h2 className="mt-3 text-3xl lg:text-4xl">{name}</h2>
           <h3>{affiliation}</h3>
           <h3 className={styles.affiliation}>{level}</h3>

--- a/app/members/[slug]/page.tsx
+++ b/app/members/[slug]/page.tsx
@@ -61,7 +61,7 @@ export default async function Member({ params }: Props) {
       />
       <div className={styles.topBar} />
       <article className="relative py-16 lg:max-w-screen-lg lg:mx-auto lg:flex lg:gap-12 lg:items-start">
-        <div className="text-center lg:shrink-0">
+        <div className="flex flex-col items-center lg:shrink-0">
           <Image
             src={`/img/members/${slug}.jpg`}
             alt={name}

--- a/app/members/page.module.css
+++ b/app/members/page.module.css
@@ -14,16 +14,22 @@
 
 .center {
   text-align: center;
-  padding-top: 120px;
+  padding-top: 80px;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  width: 100%;
 }
 
 .heading {
   margin-bottom: 48px;
 }
 
-@media (max-width: 628px) {
-  .membersPage img {
-    width: 130px;
-    height: 130px;
+@media (max-width: 640px) {
+  .center {
+    padding-top: 48px;
+  }
+
+  .heading {
+    margin-bottom: 32px;
   }
 }

--- a/components/ButtonLink/ButtonLink.module.css
+++ b/components/ButtonLink/ButtonLink.module.css
@@ -1,10 +1,15 @@
 .buttonLink {
-  padding: 18px 46px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 36px;
   background: var(--button-background);
   color: var(--white-color);
   border-radius: var(--border-radius);
   font-weight: bold;
   border: 2px solid transparent;
+  font-size: 1rem;
+  white-space: nowrap;
 }
 
 .buttonLink:hover {
@@ -16,6 +21,14 @@
 
 @media (max-width: 550px) {
   .buttonLink {
-    padding: 18px 33px;
+    padding: 14px 24px;
+    font-size: 0.9375rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .buttonLink {
+    padding: 12px 20px;
+    font-size: 0.875rem;
   }
 }

--- a/components/Footer/Footer.module.css
+++ b/components/Footer/Footer.module.css
@@ -4,9 +4,11 @@
   margin-right: auto;
   margin-top: 50px;
   color: var(--primary-color);
-  padding: 36px;
+  padding: 24px 16px;
   justify-content: space-evenly;
   display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .footer a {

--- a/components/Homepage/Hero/Hero.module.css
+++ b/components/Homepage/Hero/Hero.module.css
@@ -13,6 +13,7 @@
 .home {
   text-align: center;
   margin: 100px 0;
+  padding: 0 1.25rem;
 }
 
 .description p {
@@ -23,6 +24,7 @@
 
 @media (max-width: 550px) {
   .home {
-    margin: 70px 0px 100px;
+    margin: 56px 0 80px;
+    padding: 0 1rem;
   }
 }

--- a/components/Homepage/MemberPreview/MembersSnippet.module.css
+++ b/components/Homepage/MemberPreview/MembersSnippet.module.css
@@ -1,5 +1,6 @@
 .avatars {
-  padding: 80px 0;
+  padding: 60px 1rem;
+  width: 100%;
 }
 
 .avatars h2 {
@@ -9,31 +10,11 @@
 .cta {
   display: flex;
   justify-content: center;
+  padding: 0 1rem;
 }
 
-.avatars img {
-  border-radius: var(--border-radius);
-}
-
-@media (max-width: 628px) {
-  .avatars img {
-    width: 130px;
-    height: 130px;
+@media (max-width: 640px) {
+  .avatars {
+    padding: 40px 1rem;
   }
-}
-
-.button {
-  padding: 18px 46px;
-  background: var(--button-background);
-  color: var(--white-color);
-  border-radius: var(--border-radius);
-  font-weight: bold;
-  border: 2px solid transparent;
-}
-
-.button:hover {
-  background: var(--button-background-hover);
-  border-color: var(--button-dark-hover);
-  color: var(--button-dark-hover);
-  transition: all 150ms ease-in-out;
 }

--- a/components/MemberCard/MemberCard.tsx
+++ b/components/MemberCard/MemberCard.tsx
@@ -22,7 +22,7 @@ const MemberCard = (props: MemberProps) => {
         target="_blank"
         rel="noopener noreferrer">
         {/* Image */}
-        <div className="relative mx-auto w-[250px] h-[250px]">
+        <div className="relative mx-auto w-[160px] h-[160px] sm:w-[200px] sm:h-[200px] md:w-[250px] md:h-[250px]">
           <Image
             src={`/img/members/${slug}.jpg`}
             alt={name}

--- a/components/MemberCard/MemberCard.tsx
+++ b/components/MemberCard/MemberCard.tsx
@@ -14,15 +14,15 @@ const MemberCard = (props: MemberProps) => {
   const { name, slug, level, countries, linkedin } = props.member;
 
   return (
-    <div className={"text-center"}>
+    <div className="flex flex-col items-center text-center">
       <Link
         href={`https://linkedin.com/in/${linkedin}`}
         aria-label={name}
-        className="block"
+        className="flex flex-col items-center"
         target="_blank"
         rel="noopener noreferrer">
         {/* Image */}
-        <div className="relative mx-auto w-[160px] h-[160px] sm:w-[200px] sm:h-[200px] md:w-[250px] md:h-[250px]">
+        <div className="relative w-[160px] h-[160px] sm:w-[200px] sm:h-[200px] md:w-[250px] md:h-[250px]">
           <Image
             src={`/img/members/${slug}.jpg`}
             alt={name}

--- a/components/Navbar/Navbar.module.css
+++ b/components/Navbar/Navbar.module.css
@@ -2,7 +2,8 @@
   justify-content: space-between;
   font-weight: bold;
   text-align: center;
-  margin: 24px;
+  margin: 24px 16px;
+  padding: 0 8px;
 }
 
 .navbar ul {
@@ -11,7 +12,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 4px 1.5rem;
+  gap: 4px 1.25rem;
 }
 
 .navbar li {
@@ -20,11 +21,22 @@
 }
 
 .navbar a {
-  margin-bottom: 15px;
+  display: inline-block;
+  padding: 6px 4px;
   text-decoration: underline;
 }
 
 .navbar li:hover {
   color: var(--primary-color);
   transition: all 150ms ease-in-out;
+}
+
+@media (max-width: 400px) {
+  .navbar {
+    margin: 16px 12px;
+  }
+
+  .navbar ul {
+    gap: 2px 1rem;
+  }
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -45,12 +45,12 @@ h1 {
 
 h2 {
   font-family: "Latina Heavy", sans-serif;
-  font-size: 40px;
+  font-size: clamp(1.75rem, 6vw, 2.5rem);
 }
 
 h3 {
   font-family: "Latina Bold", sans-serif;
-  font-size: 23px;
+  font-size: clamp(1.1rem, 4vw, 1.4375rem);
 }
 
 h4,


### PR DESCRIPTION
- MemberCard: responsive image container (160px mobile → 250px desktop)
- Member profile page: reduce excessive p-10 padding to px-4/py-6 on mobile; responsive image sizing
- Members page: add horizontal padding, reduce top padding on mobile, remove broken media query targeting unused class
- ButtonLink: use inline-flex with gap for icon alignment; improve padding/font-size on small screens
- Navbar: better touch targets (inline-block padding on links), reduced margin on small screens
- MembersSnippet: remove non-functional img media query (fill images use container sizing); add horizontal padding
- Footer: wrap icon row and reduce padding on mobile
- Hero: add horizontal padding on small screens
- base.css: use clamp() for h2 and h3 so they scale fluidly on small viewports

https://claude.ai/code/session_01L4bTn7DCZwf8VT54bK6qhY